### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ LOG_MAP_RECT(mapRect)
 Simply call macros you want to use with appropriate parameters
 
 ##Installation
-__Cocoapods__: `pod 'GONMacros'`<br>
+__CocoaPods__: `pod 'GONMacros'`<br>
 __Manual__: Copy the __Classes__ folder in your project<br>
 
 Import wanted headers in your project. .pch is a good place ;)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
